### PR TITLE
feat: change the array input from two-sided constraints to general form

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ MPAX implements two state-of-the-art first-order methods for solving LP problems
 ```python
 from mpax import create_lp, r2HPDHG
 
-lp = create_lp(c, A, l, u, var_lb, var_ub)
+lp = create_lp(c, A, b, G, h, l, u)
 solver = r2HPDHG(eps_abs=1e-4, eps_rel=1e-4, verbose=True)
 result = solver.optimize(lp)
 ```
@@ -58,7 +58,7 @@ import jax.numpy as jnp
 from mpax import create_lp, r2HPDHG
 
 def single_optimize(c_vector):
-    lp = create_lp(c_vector, A, l, u, var_lb, var_ub)
+    lp = create_lp(c_vector, A, b, G, h, l, u)
     solver = r2HPDHG(eps_abs=1e-4, eps_rel=1e-4, verbose=True)
     result = solver.optimize(lp)
     obj = jnp.dot(c_vector, result.primal_solution)
@@ -83,7 +83,7 @@ mesh = jax.make_mesh((2,), ('x',))
 sharding = jax.sharding.NamedSharding(mesh, P('x',))
 
 A_sharded = jax.device_put(A, sharding)
-lp_sharded = create_lp(c, A_sharded, l, u, var_lb, var_ub)
+lp_sharded = create_lp(c, A_sharded, b, G, h, l, u)
 
 solver = r2HPDHG(eps_abs=1e-4, eps_rel=1e-4, verbose=True)
 jit_optimize = jax.jit(solver.optimize)

--- a/mpax/r2hpdhg.py
+++ b/mpax/r2hpdhg.py
@@ -49,7 +49,6 @@ class r2HPDHG(raPDHG):
     optimality_norm: int = OptimalityNorm.L2
     eps_abs: float = 1e-4
     eps_rel: float = 1e-4
-    eps_ratio: float = 1.0
     eps_primal_infeasible: float = 1e-8
     eps_dual_infeasible: float = 1e-8
     # time_sec_limit: float = float("inf")
@@ -312,7 +311,6 @@ class r2HPDHG(raPDHG):
                 qp_cache,
                 solver_state.numerical_error,
                 1.0,
-                self.eps_ratio,
                 self.termination_evaluation_frequency * self.display_frequency,
                 False,
             ),

--- a/mpax/rapdhg.py
+++ b/mpax/rapdhg.py
@@ -282,7 +282,6 @@ class raPDHG(abc.ABC):
     optimality_norm: int = OptimalityNorm.L2
     eps_abs: float = 1e-4
     eps_rel: float = 1e-4
-    eps_ratio: float = 1.0
     eps_primal_infeasible: float = 1e-8
     eps_dual_infeasible: float = 1e-8
     # time_sec_limit: float = float("inf")
@@ -538,7 +537,6 @@ class raPDHG(abc.ABC):
                 qp_cache,
                 solver_state.numerical_error,
                 1.0,
-                self.eps_ratio,
                 self.termination_evaluation_frequency * self.display_frequency,
             ),
             lambda: (False, TerminationStatus.UNSPECIFIED),

--- a/mpax/termination.py
+++ b/mpax/termination.py
@@ -191,7 +191,6 @@ def check_termination_criteria(
     qp_cache: CachedQuadraticProgramInfo,
     numerical_error: bool,
     elapsed_time: float,
-    eps_ratio: float,
     display_frequency: int,
     average: bool = True,
 ) -> Union[str, bool]:
@@ -212,6 +211,7 @@ def check_termination_criteria(
     Union[str, bool]
         Termination reason if criteria are met, False otherwise.
     """
+    eps_ratio = criteria.eps_abs / criteria.eps_rel
     current_iteration_stats = evaluate_unscaled_iteration_stats(
         scaled_problem,
         qp_cache,

--- a/tests/r2hpdhg_test.py
+++ b/tests/r2hpdhg_test.py
@@ -52,40 +52,52 @@ def test_r2hpdhg_with_vmap():
     var, prob = LpProblem.fromMPS("tests/lp_instances/gen-ip054.mps")
     c, integrality, constraints, bounds = convert_all(prob)
     c = jnp.array(c)
-    A = BCOO.fromdense(constraints.A)
-    l = jnp.array(constraints.lb)
-    u = jnp.array(constraints.ub)
+    constraint_lb = jnp.array(constraints.lb)
+    constraint_ub = jnp.array(constraints.ub)
+
+    eq_mask = constraint_lb == constraint_ub
+    leq_mask = constraint_lb == -jnp.inf
+    geq_mask = constraint_ub == jnp.inf
+    A = BCOO.fromdense(constraints.A[eq_mask])
+    b = jnp.array(constraint_lb[eq_mask])
+
+    leq_G = -constraints.A[leq_mask]
+    leq_rhs = -constraint_ub[leq_mask]
+    geq_G = constraints.A[geq_mask]
+    geq_rhs = constraint_lb[geq_mask]
+    G = BCOO.fromdense(jnp.concatenate([leq_G, geq_G], axis=0))
+    h = jnp.concatenate([leq_rhs, geq_rhs], axis=0)
     var_lb = jnp.array(bounds.lb)
     var_ub = jnp.array(bounds.ub)
 
     solver = r2HPDHG(eps_abs=1e-6, eps_rel=1e-6)
-    jit_optimize = jit(solver.optimize)
 
     def solve_single(c):
-        boxed_lp = create_lp(c, A, l, u, var_lb, var_ub)
-        # result = solver.optimize(boxed_lp)
-        result = jit_optimize(boxed_lp)
+        boxed_lp = create_lp(c, A, b, G, h, var_lb, var_ub)
+        result = solver.optimize(boxed_lp)
         return (
             jnp.dot(boxed_lp.objective_vector, result.primal_solution)
             + boxed_lp.objective_constant
         )
 
+    jit_solve_single = jit(solve_single)
+
     start_time = timeit.default_timer()
-    objective_value = solve_single(c)
+    objective_value = jit_solve_single(c)
     print("1st single run time = ", timeit.default_timer() - start_time)
 
-    # # Expected optimal objective value
+    # Expected optimal objective value
     expected_obj = 6.765209043e03
     assert pytest.approx(objective_value, rel=1e-2) == expected_obj
 
     start_time = timeit.default_timer()
-    objective_value = solve_single(c)
+    objective_value = jit_solve_single(c)
     print("2nd single run time = ", timeit.default_timer() - start_time)
     assert pytest.approx(objective_value, rel=1e-2) == expected_obj
 
     batch_size = 100
     batch_c = jnp.tile(c, (batch_size, 1))
-    batch_optimize = vmap(solve_single)
+    batch_optimize = vmap(jit(solve_single))
 
     start_time = timeit.default_timer()
     batch_result = batch_optimize(batch_c)


### PR DESCRIPTION
# Fix #1

This PR updates the `create_lp` function interface for improved usability and compatibility. 

The function input has been changed from:  
`create_lp(c, A, l, u, var_lb, var_ub)`  
to:  
`create_lp(c, A, b, G, h, l, u)`.  

Key changes include:
- Two-sided constraints are no longer supported in this implementation.
- The new `create_lp(c, A, b, G, h, l, u)` function is now fully JIT-compatible.
