### PR TITLE
fix: rapdhg constant stepsize nan error

### DIFF
--- a/tests/rapdhg_test.py
+++ b/tests/rapdhg_test.py
@@ -35,6 +35,17 @@ def test_rapdhg_lp():
         assert pytest.approx(result.primal_objective, rel=1e-2) == expected_obj
 
 
+def test_rapdhg_lp_constant_stepsize():
+    """Test the raPDHG solver on a sample LP problem."""
+    for model_filename, expected_obj in lp_model_objs.items():
+        gurobi_model = gp.read(pytest_cache_dir + "/" + model_filename)
+        qp = create_qp_from_gurobi(gurobi_model)
+        solver = raPDHG(adaptive_step_size=False, eps_abs=1e-6, eps_rel=1e-6)
+        result = solver.optimize(qp)
+
+        assert pytest.approx(result.primal_objective, rel=1e-2) == expected_obj
+
+
 def test_rapdhg_qp():
     """Test the raPDHG solver on a sample LP problem."""
     for model_filename, expected_obj in qp_model_objs.items():


### PR DESCRIPTION
## Fixes #14 
Fixes the `NaN` error caused by computing the maximal singular value of an empty objective matrix in LP problems. Now set to `0.0` directly.