### PR TITLE
fix: the display_problem_details not support dense matrix error

### DIFF
--- a/tests/rapdhg_test.py
+++ b/tests/rapdhg_test.py
@@ -69,6 +69,17 @@ def test_rapdhg_lp_with_jit():
         assert pytest.approx(result.primal_objective, rel=1e-2) == expected_obj
 
 
+def test_rapdhg_lp_with_jit_dense_matrix():
+    """Test the raPDHG solver on a sample LP problem."""
+    for model_filename, expected_obj in lp_model_objs.items():
+        gurobi_model = gp.read(pytest_cache_dir + "/" + model_filename)
+        qp = create_qp_from_gurobi(gurobi_model, use_sparse_matrix=False)
+        solver = raPDHG(eps_abs=1e-6, eps_rel=1e-6, verbose=True)
+        result = solver.optimize(qp)
+
+        assert pytest.approx(result.primal_objective, rel=1e-2) == expected_obj
+
+
 def test_rapdhg_qp_with_jit():
     """Test the raPDHG solver on a sample LP problem."""
     for model_filename, expected_obj in qp_model_objs.items():


### PR DESCRIPTION
## Fixes #13 
The `display_problem_details` function previously did not support dense matrix format since it used `matrix.data`, which only exists in `BCOO` or `BSCR`.